### PR TITLE
feat(cli): minimal CLI support for alhazen

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,55 @@ For our calculator, the learned decision tree looks something like this:
 
 We see that the failure occurs whenever we use the _sqrt(x)_ function and the number x has a negative sign!
 
+## Using Alhazen from the command line (CLI)
+
+Alhazen-py offers a minimal CLI tool. It expects a python-file where the needed data and code is supplied (e.g. as in `src/alhazen_formalizations/calculator.py`).
+
+```shell
+alhazen [...] your_program.py
+
+# how to use the calculator example
+alhazen src/alhazen_formalizations/calculator.py -e=prop -g=grammar -i=initial_inputs
+
+# if you use the default names, you can omit them from the command
+alhazen src/alhazen_formalizations/calculator.py -e=prop
+```
+
+Currently, the following Alhazen attributes are supported as parameters for the CLI:
+
+<ul>
+<li>initials_inputs</li>
+<li>grammar</li>
+<li>evaluation_function</li>
+</ul>
+
+### Specifying your output and getting help
+
+By default, the CLI will print out result to stdout, with you being able to specify the output format:
+
+```shell
+# use the sklearn.tree.export_text() text representation
+alhazen your_program.py -F=0
+
+# use the sklearn.tree.export_graphviz() dot model representation
+alhazen your_program.py --format=1
+```
+
+For further visualization you can for example pipe the output to `dot` and get an SVG (prerequisite: `graphviz`):
+```shell
+# create a svg of the tree by piping alhazens output to dot
+alhazen src/alhazen_formalizations/calculator.py -e=prop | dot -Tsvg > output.svg
+```
+
+Miscellaneous:
+```shell
+# If you need help, check the help page
+alhazen --help
+
+# You can increase output verbosity with -v or --verbosity
+alhazen -v ...
+```
+
 ## Project Structure
 
 In this repository, you find:
@@ -116,6 +165,9 @@ source venv/bin/activate
 
 pip install --upgrade pip
 pip install alhazen-py
+
+# check if alhazen was installed correctly
+alhazen --version
 ```
 
 Now, the alhazen command should be available on the command line within the virtual environment.

--- a/src/alhazen/alhazen.py
+++ b/src/alhazen/alhazen.py
@@ -14,6 +14,8 @@ from alhazen.oracle import OracleResult
 from alhazen.features import FeatureWrapper, STANDARD_FEATURES
 from alhazen.feature_collector import Collector
 from alhazen.helper import show_tree
+from alhazen.helper import get_clf_text
+from alhazen.helper import get_dot_data
 
 GENERATOR_TIMEOUT = 10  # timeout in seconds
 MAX_ITERATION = 20
@@ -21,15 +23,15 @@ MAX_ITERATION = 20
 
 class Alhazen:
     def __init__(
-        self,
-        initial_inputs: List[str],
-        grammar: Grammar,
-        evaluation_function: Callable,
-        max_iter: int = 10,
-        generator_timeout: int = 10,
-        generator: Union[Generator | None] = None,
-        learner: Union[Learner | None] = None,
-        features: Set[FeatureWrapper] = STANDARD_FEATURES,
+            self,
+            initial_inputs: List[str],
+            grammar: Grammar,
+            evaluation_function: Callable,
+            max_iter: int = 10,
+            generator_timeout: int = 10,
+            generator: Union[Generator | None] = None,
+            learner: Union[Learner | None] = None,
+            features: Set[FeatureWrapper] = STANDARD_FEATURES,
     ):
         self._initial_inputs: List[str] = initial_inputs
         self._grammar: grammar = grammar
@@ -149,6 +151,12 @@ class Alhazen:
 
     def show_model(self):
         return show_tree(self._models[-1], self._all_features)
+
+    def get_clf_model(self):
+        return get_clf_text(self._models[-1], self._all_features)
+
+    def get_dot_model(self):
+        return get_dot_data(self._models[-1], self._all_features)
 
     def predict(self) -> OracleResult:
         raise NotImplementedError("predict function not yet implemented")

--- a/src/alhazen/cli.py
+++ b/src/alhazen/cli.py
@@ -1,0 +1,95 @@
+import argparse
+import sys
+from datetime import datetime
+from importlib.metadata import version
+import importlib.util
+
+from alhazen import Alhazen
+
+
+def main():
+
+    parser = argparse.ArgumentParser(description="Alhazen (v%s) is a debugging tool, that tries to automatically learn "
+                                                 "associations between program failures in connection to their "
+                                                 "inputs. Results are be printed to stdout. You can change the output "
+                                                 "format."
+                                                 % (version("alhazen-py")),
+                                     epilog="To find out more, check out the repository at "
+                                            "https://github.com/martineberlein/alhazen-py .")
+
+    parser.add_argument("program",
+                        help="path to a python file under test, currently only one source file is supported by the CLI",
+                        type=str)
+
+    # optional arguments, sorted alphabetically
+    parser.add_argument("-e", "--evaluation_function",
+                        help="specify the name of the method under test (default = evaluation_function)",
+                        type=str,
+                        metavar="EVAL_FUNC",
+                        default="evaluation_function")
+    parser.add_argument("-g", "--grammar",
+                        help="specify the name of the grammar to be used (default = grammar)",
+                        type=str,
+                        default="grammar")
+    parser.add_argument("-i", "--initial_inputs",
+                        help="specify the name of the initial inputs to be used (default initial_inputs)",
+                        type=str,
+                        metavar="INIT_INPUTS",
+                        default="initial_inputs")
+
+    # more optional arguments, sorted alphabetically
+    # parser.add_argument("-f", "--features") TODO
+    parser.add_argument("-F", "--format",
+                        type=int,
+                        default=0,
+                        help="define the output form to stdout (0: clf text, 1: dot model)")
+    # parser.add_argument("-G", "--generator") TODO
+    parser.add_argument("-t", "--generator_timeout",
+                        type=int,
+                        metavar="GEN_TIMEOUT",
+                        default=10)
+    # parser.add_argument("-l", "--learner") TODO
+    parser.add_argument("-m", "--max_iter",
+                        type=int,
+                        default=10)
+    parser.add_argument("-v", "--verbosity",
+                        action="count",
+                        default=0,
+                        help="increase output verbosity")
+    parser.add_argument("-V", "--version",
+                        action="version",
+                        version="alhazen-py %s" % (version("alhazen-py")))
+
+    args = parser.parse_args()
+
+    module_name = args.program
+    file_path = args.program
+
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+    if args.verbosity >= 1:
+        print("Starting up Alhazen with %s." % args.program)
+        print("Started at %s with the following configuration:" % str(datetime.now()))
+        print("evaluation_function: %s, grammar: %s, initial_inputs: %s"
+              % (args.evaluation_function, args.grammar, args.initial_inputs))
+
+    alhazen = Alhazen(initial_inputs=getattr(module, args.initial_inputs),
+                      grammar=getattr(module, args.grammar),
+                      evaluation_function=getattr(module, args.evaluation_function))
+
+    alhazen.run()
+
+    if args.verbosity >= 1:
+        print("\nResult start here:\n")
+
+    if args.format == 0:
+        print(alhazen.get_clf_model())
+    elif args.format == 1:
+        print(alhazen.get_dot_model())
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/src/alhazen/helper.py
+++ b/src/alhazen/helper.py
@@ -16,6 +16,13 @@ def show_tree(clf, feature_names):
     return graphviz.Source(dot_data)
 
 
+def get_clf_text(clf, feature_names):
+    clf_text = tree.export_text(
+        decision_tree=clf,
+        feature_names=feature_names)
+    return clf_text
+
+
 def get_dot_data(clf, feature_names):
     dot_data = tree.export_graphviz(
         clf,


### PR DESCRIPTION
Introduce suppport for a minimal CLI for alhazen-py.
Includes functionality to run Alhazen from the command line with the ability to specifiy the basic Alhazen attributes, sourced from a python file, for:
- grammar
- initial_inputs
- evaluation_function

Also allows to change between two output formats for the learned DecisionTreeClassifier:
- text representation
- dot model representation for graphivz

The README.md has been extended with a short description on how to use the CLI.